### PR TITLE
Specify supported rector version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ on:
             - 'main'
             - '[0-9]+.x'
             - '[0-9]+.[0-9]+'
+    schedule:
+        - cron: "0 0 * * 0"
 
 # automatically cancel previously started workflows when pushing a new commit to a branch
 concurrency:
@@ -26,6 +28,8 @@ jobs:
             fail-fast: false
             matrix:
                 include:
+                    - php-version: '8.1'
+                      dependency-versions: 'lowest'
                     - php-version: '8.1'
                       dependency-versions: 'highest'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sulu Rector
 
-This project contains [Rector rules](https://github.com/rectorphp/rector) for Sulu CMS upgrades.
+This project contains [Rector rules](https://github.com/rectorphp/rector) for [Sulu CMS](https://github.com/sulu/sulu) upgrades.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sulu Rector
 
-Rector rules for Sulu CMS upgrades.
+This project contains [Rector rules](https://github.com/rectorphp/rector) for Sulu CMS upgrades.
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "Sulu CMS"
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "rector/rector": "^0.12.22"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.6",
@@ -19,7 +20,6 @@
         "phpstan/phpstan-strict-rules": "^1.1",
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "dev-main",
         "sulu/sulu": "^2.5@dev",
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
@@ -36,9 +36,6 @@
         "classmap": [
             "stubs"
         ]
-    },
-    "conflict": {
-        "rector/rector": "<0.11"
     },
     "scripts": {
         "lint": [
@@ -59,7 +56,6 @@
         "test": "@php vendor/bin/phpunit"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {


### PR DESCRIPTION
I think I need to specify the supported rector version as require else it could make problems in the future. Via `"prefer-stable": true,` I still make sure tests are run against dev version of rector via `"minimum-stability": "dev"` without prefer stable.