### PR TITLE
Increase Rector requirement to 0.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "rector/rector": "^0.17.2 || ^0.18"
+        "rector/rector": "^0.19"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.6",
@@ -22,9 +22,6 @@
         "phpunit/phpunit": "^9.5.20",
         "sulu/sulu": "^2.5@dev",
         "thecodingmachine/phpstan-strict-rules": "^1.0"
-    },
-    "conflict": {
-        "phpstan/phpstan": ">=1.10.55"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This removes the conflicts to phpstan 1.10.55 from #23 by require atleast rector 0.19.