### PR TITLE
[Draft] Adding a migration for 3.0

### DIFF
--- a/config/sets/sulu/level/up-to-sulu-30.php
+++ b/config/sets/sulu/level/up-to-sulu-30.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Sulu\Rector\Set\SuluLevelSetList;
+use Sulu\Rector\Set\SuluSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([SuluSetList::SULU_30, SuluLevelSetList::UP_TO_SULU_26]);
+};

--- a/config/sets/sulu/sulu-26.php
+++ b/config/sets/sulu/sulu-26.php
@@ -3,6 +3,46 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Sulu\Rector\Rector\ListBuilderInterfaceRector;
+use Sulu\Rector\Rector\PaginatedRepresentationRector;
+use Sulu\Rector\Rector\RequestParameterTraitRector;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(
+        RenameMethodRector::class,
+        [
+            // @see Removing old Category functions https://github.com/sulu/sulu/pull/7572
+            new MethodCallRename(
+                'Sulu\Bundle\CategoryBundle\Entity\CategoryRepository',
+                'findByCategoryIds',
+                'findByCategoriesIds',
+            ),
+            new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'addChildren', 'addChild'),
+            new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'removeChildren', 'removeChild'),
+
+            new MethodCallRename('Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder', 'setRequestParameters', 'addRequestParameters'),
+
+            // @see Removing old ListBuilderInterface functions https://github.com/sulu/sulu/pull/7752
+            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'setFields', 'setSelectFields'),
+            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'addField', 'addSelectField'),
+            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'hasField', 'hasSelectField'),
+
+            // @see Deprecating Localization https://github.com/sulu/sulu/pull/7053
+            new MethodCallRename('Sulu\Component\Webspace\Portal', 'getXDefaultLocalization', 'getDefaultLocalization'),
+            new MethodCallRename('Sulu\Component\Webspace\Portal', 'setXDefaultLocalization', 'setDefaultLocalization'),
+            new MethodCallRename('Sulu\Component\Localization\Localization', 'isXDefault', 'isDefault'),
+            new MethodCallRename('Sulu\Component\Security\Event\PermissionUpdateEvent', 'getSecurityIdentity', 'getPermissions'),
+        ],
+    );
+
+    // @see Replacing the RequestParameterTrait: https://github.com/sulu/sulu/pull/7815
+    $rectorConfig->rule(RequestParameterTraitRector::class);
+
+    // @see Manually fixing whereNot -> where: https://github.com/sulu/sulu/pull/7752
+    $rectorConfig->rule(ListBuilderInterfaceRector::class);
+
+    // @see ListRepresentation -> PaginatedRepresentation https://github.com/sulu/sulu/pull/7740
+    $rectorConfig->rule(PaginatedRepresentationRector::class);
 };

--- a/config/sets/sulu/sulu-30.php
+++ b/config/sets/sulu/sulu-30.php
@@ -13,7 +13,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
         RenameMethodRector::class,
         [
-            // Removing old Category functions https://github.com/sulu/sulu/pull/7572
+            // @see Removing old Category functions https://github.com/sulu/sulu/pull/7572
             new MethodCallRename(
                 'Sulu\Bundle\CategoryBundle\Entity\CategoryRepository',
                 'findByCategoryIds',
@@ -24,19 +24,25 @@ return static function (RectorConfig $rectorConfig): void {
 
             new MethodCallRename('Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder', 'setRequestParameters', 'addRequestParameters'),
 
-            // Removing old ListBuilderInterface functions https://github.com/sulu/sulu/pull/7752
+            // @see Removing old ListBuilderInterface functions https://github.com/sulu/sulu/pull/7752
             new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'setFields', 'setSelectFields'),
             new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'addField', 'addSelectField'),
             new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'hasField', 'hasSelectField'),
+
+            // @see Deprecating Localization https://github.com/sulu/sulu/pull/7053
+            new MethodCallRename('Sulu\Component\Webspace\Portal', 'getXDefaultLocalization', 'getDefaultLocalization'),
+            new MethodCallRename('Sulu\Component\Webspace\Portal', 'setXDefaultLocalization', 'setDefaultLocalization'),
+            new MethodCallRename('Sulu\Component\Localization\Localization', 'isXDefault', 'isDefault'),
+            new MethodCallRename('Sulu\Component\Security\Event\PermissionUpdateEvent', 'getSecurityIdentity', 'getPermissions'),
         ],
     );
 
-    // Replacing the RequestParameterTrait: https://github.com/sulu/sulu/pull/7815
+    // @see Replacing the RequestParameterTrait: https://github.com/sulu/sulu/pull/7815
     $rectorConfig->rule(RequestParameterTraitRector::class);
 
-    // Manually fixing whereNot -> where: https://github.com/sulu/sulu/pull/7752
+    // @see Manually fixing whereNot -> where: https://github.com/sulu/sulu/pull/7752
     $rectorConfig->rule(ListBuilderInterfaceRector::class);
 
-    // ListRepresentation -> PaginatedRepresentation https://github.com/sulu/sulu/pull/7740
+    // @see ListRepresentation -> PaginatedRepresentation https://github.com/sulu/sulu/pull/7740
     $rectorConfig->rule(PaginatedRepresentationRector::class);
 };

--- a/config/sets/sulu/sulu-30.php
+++ b/config/sets/sulu/sulu-30.php
@@ -6,12 +6,14 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Sulu\Rector\Rector\ListBuilderInterfaceRector;
+use Sulu\Rector\Rector\PaginatedRepresentationRector;
 use Sulu\Rector\Rector\RequestParameterTraitRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
         RenameMethodRector::class,
         [
+            // Removing old Category functions https://github.com/sulu/sulu/pull/7572
             new MethodCallRename(
                 'Sulu\Bundle\CategoryBundle\Entity\CategoryRepository',
                 'findByCategoryIds',
@@ -19,13 +21,22 @@ return static function (RectorConfig $rectorConfig): void {
             ),
             new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'addChildren', 'addChild'),
             new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'removeChildren', 'removeChild'),
+
             new MethodCallRename('Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder', 'setRequestParameters', 'addRequestParameters'),
+
+            // Removing old ListBuilderInterface functions https://github.com/sulu/sulu/pull/7752
             new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'setFields', 'setSelectFields'),
             new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'addField', 'addSelectField'),
             new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'hasField', 'hasSelectField'),
         ],
     );
 
+    // Replacing the RequestParameterTrait: https://github.com/sulu/sulu/pull/7815
     $rectorConfig->rule(RequestParameterTraitRector::class);
+
+    // Manually fixing whereNot -> where: https://github.com/sulu/sulu/pull/7752
     $rectorConfig->rule(ListBuilderInterfaceRector::class);
+
+    // ListRepresentation -> PaginatedRepresentation https://github.com/sulu/sulu/pull/7740
+    $rectorConfig->rule(PaginatedRepresentationRector::class);
 };

--- a/config/sets/sulu/sulu-30.php
+++ b/config/sets/sulu/sulu-30.php
@@ -3,46 +3,29 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
-use Rector\Renaming\ValueObject\MethodCallRename;
-use Sulu\Rector\Rector\ListBuilderInterfaceRector;
-use Sulu\Rector\Rector\PaginatedRepresentationRector;
-use Sulu\Rector\Rector\RequestParameterTraitRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(
-        RenameMethodRector::class,
-        [
-            // @see Removing old Category functions https://github.com/sulu/sulu/pull/7572
-            new MethodCallRename(
-                'Sulu\Bundle\CategoryBundle\Entity\CategoryRepository',
-                'findByCategoryIds',
-                'findByCategoriesIds',
-            ),
-            new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'addChildren', 'addChild'),
-            new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'removeChildren', 'removeChild'),
+    $classRenames = [
+        'Sulu\Bundle\RouteBundle\Model\RoutableInterface' => 'Sulu\Bundle\ContentBundle\Content\Domain\Model\RoutableTrait',
+    ];
 
-            new MethodCallRename('Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder', 'setRequestParameters', 'addRequestParameters'),
+    $modelClasses = [
+        'ContentRichEntityInterface',
+        'DimensionContentInterface',
+        'DimensionContentTrait',
+        'RoutableInterface',
+        'TemplateInterface',
+        'TemplateTrait',
+        'WorkflowInterface',
+        'WorkflowTrait',
+    ];
 
-            // @see Removing old ListBuilderInterface functions https://github.com/sulu/sulu/pull/7752
-            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'setFields', 'setSelectFields'),
-            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'addField', 'addSelectField'),
-            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'hasField', 'hasSelectField'),
+    // Content Bundle
+    foreach ($modelClasses as $modelClass) {
+        $classRenames['Sulu\\Bundle\\ContentBundle\\Content\\Domain\\Model\\' . $modelClass] = 'Sulu\\Content\\Domain\\Model\\' . $modelClass;
+    }
 
-            // @see Deprecating Localization https://github.com/sulu/sulu/pull/7053
-            new MethodCallRename('Sulu\Component\Webspace\Portal', 'getXDefaultLocalization', 'getDefaultLocalization'),
-            new MethodCallRename('Sulu\Component\Webspace\Portal', 'setXDefaultLocalization', 'setDefaultLocalization'),
-            new MethodCallRename('Sulu\Component\Localization\Localization', 'isXDefault', 'isDefault'),
-            new MethodCallRename('Sulu\Component\Security\Event\PermissionUpdateEvent', 'getSecurityIdentity', 'getPermissions'),
-        ],
-    );
-
-    // @see Replacing the RequestParameterTrait: https://github.com/sulu/sulu/pull/7815
-    $rectorConfig->rule(RequestParameterTraitRector::class);
-
-    // @see Manually fixing whereNot -> where: https://github.com/sulu/sulu/pull/7752
-    $rectorConfig->rule(ListBuilderInterfaceRector::class);
-
-    // @see ListRepresentation -> PaginatedRepresentation https://github.com/sulu/sulu/pull/7740
-    $rectorConfig->rule(PaginatedRepresentationRector::class);
+    // TODO: Add all the renames for bundles here:
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, $classRenames);
 };

--- a/config/sets/sulu/sulu-30.php
+++ b/config/sets/sulu/sulu-30.php
@@ -19,6 +19,9 @@ return static function (RectorConfig $rectorConfig): void {
             new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'addChildren', 'addChild'),
             new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'removeChildren', 'removeChild'),
             new MethodCallRename('Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder', 'setRequestParameters', 'addRequestParameters'),
+            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'setFields', 'setSelectFields'),
+            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'addField', 'addSelectField'),
+            new MethodCallRename('Sulu\Component\Rest\ListBuilder\ListBuilderInterface', 'hasField', 'hasSelectField'),
         ],
     );
 

--- a/config/sets/sulu/sulu-30.php
+++ b/config/sets/sulu/sulu-30.php
@@ -15,6 +15,9 @@ return static function (RectorConfig $rectorConfig): void {
                 'findByCategoryIds',
                 'findByCategoriesIds',
             ),
+            new MethodCallRename( 'Sulu\Bundle\CategoryBundle\Entity\Category', 'addChildren', 'addChild'),
+            new MethodCallRename( 'Sulu\Bundle\CategoryBundle\Entity\Category', 'removeChildren', 'removeChild'),
+            new MethodCallRename( 'Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder', 'setRequestParameters', 'addRequestParameters'),
         ],
     );
 };

--- a/config/sets/sulu/sulu-30.php
+++ b/config/sets/sulu/sulu-30.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(
+        RenameMethodRector::class,
+        [
+            new MethodCallRename(
+                'Sulu\Bundle\CategoryBundle\Entity\CategoryRepository',
+                'findByCategoryIds',
+                'findByCategoriesIds',
+            ),
+        ],
+    );
+};
+

--- a/config/sets/sulu/sulu-30.php
+++ b/config/sets/sulu/sulu-30.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Sulu\Rector\Rector\ListBuilderInterfaceRector;
 use Sulu\Rector\Rector\RequestParameterTraitRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -26,4 +27,5 @@ return static function (RectorConfig $rectorConfig): void {
     );
 
     $rectorConfig->rule(RequestParameterTraitRector::class);
+    $rectorConfig->rule(ListBuilderInterfaceRector::class);
 };

--- a/config/sets/sulu/sulu-30.php
+++ b/config/sets/sulu/sulu-30.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Sulu\Rector\Rector\RequestParameterTraitRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
@@ -15,10 +16,11 @@ return static function (RectorConfig $rectorConfig): void {
                 'findByCategoryIds',
                 'findByCategoriesIds',
             ),
-            new MethodCallRename( 'Sulu\Bundle\CategoryBundle\Entity\Category', 'addChildren', 'addChild'),
-            new MethodCallRename( 'Sulu\Bundle\CategoryBundle\Entity\Category', 'removeChildren', 'removeChild'),
-            new MethodCallRename( 'Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder', 'setRequestParameters', 'addRequestParameters'),
+            new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'addChildren', 'addChild'),
+            new MethodCallRename('Sulu\Bundle\CategoryBundle\Entity\Category', 'removeChildren', 'removeChild'),
+            new MethodCallRename('Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder', 'setRequestParameters', 'addRequestParameters'),
         ],
     );
-};
 
+    $rectorConfig->rule(RequestParameterTraitRector::class);
+};

--- a/src/Rector/ListBuilderInterfaceRector.php
+++ b/src/Rector/ListBuilderInterfaceRector.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Rector\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\RectorInterface;
+use Rector\Rector\AbstractRector;
+use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ListBuilderInterfaceRector extends AbstractRector implements RectorInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Fixes ListBuilderInterface',
+            [
+                new CodeSample(
+                    <<<CODE_SAMPLE
+                    use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
+                    class Test implements ListBuilderInterface {
+                        public function invoke() {
+                            \$this->whereNot(\$fieldDescriptor, 'value');
+                        }
+                    }
+                    CODE_SAMPLE,
+                    <<<CODE_SAMPLE
+                    use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
+                    class Test implements ListBuilderInterface {
+                        public function invoke() {
+                            \$this->where(\$fieldDescriptor, 'value', ListBuilderInterface::WHERE_COMPARATOR_UNEQUAL);
+                        }
+                    }
+                    CODE_SAMPLE
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node)
+    {
+        /** @var MethodCall $node */
+        $objectType = new ObjectType(ListBuilderInterface::class);
+        if (!$this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType($node, $objectType)) {
+            return null;
+        }
+
+        $node->name = new Identifier('where');
+        $node->args[] = new Arg(
+            new ClassConstFetch(
+                new Name(['ListBuilderInterface']),
+                new Identifier('WHERE_COMPARATOR_UNEQUAL'),
+            ),
+        );
+
+        return $node;
+    }
+}

--- a/src/Rector/ListBuilderInterfaceRector.php
+++ b/src/Rector/ListBuilderInterfaceRector.php
@@ -51,11 +51,15 @@ class ListBuilderInterfaceRector extends AbstractRector implements RectorInterfa
         return [MethodCall::class];
     }
 
-    public function refactor(Node $node)
+    public function refactor(Node $node): ?Node
     {
         /** @var MethodCall $node */
         $objectType = new ObjectType(ListBuilderInterface::class);
         if (!$this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType($node, $objectType)) {
+            return null;
+        }
+
+        if (!$this->isName($node->name, 'whereNot')) {
             return null;
         }
 
@@ -65,6 +69,7 @@ class ListBuilderInterfaceRector extends AbstractRector implements RectorInterfa
                 new Name(['ListBuilderInterface']),
                 new Identifier('WHERE_COMPARATOR_UNEQUAL'),
             ),
+            name: new Identifier('comparator'),
         );
 
         return $node;

--- a/src/Rector/PaginatedRepresentationRector.php
+++ b/src/Rector/PaginatedRepresentationRector.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Rector\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Cast\Int_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\NodeVisitor;
+use Rector\Contract\Rector\RectorInterface;
+use Rector\Rector\AbstractRector;
+use Sulu\Component\Rest\ListBuilder\ListRepresentation;
+
+class PaginatedRepresentationRector extends AbstractRector implements RectorInterface
+{
+    public function getNodeTypes(): array
+    {
+        return [Use_::class, New_::class];
+    }
+
+    public function refactor(Node $node)
+    {
+        // Removing the use statement of the class
+        if ($node instanceof Use_) {
+            $counter = \count($node->uses);
+            for ($i = 0; $i < $counter; ++$i) {
+                if ($this->isName($node->uses[$i], ListRepresentation::class)) {
+                    unset($node->uses[$i]);
+                }
+            }
+            if (0 === \count($node->uses)) {
+                return NodeVisitor::REMOVE_NODE;
+            }
+        }
+
+        // Refactoring all "new" calls to that class
+        if ($node instanceof New_) {
+            if (!$this->isName($node->class, ListRepresentation::class)) {
+                return null;
+            }
+            $node->class = new FullyQualified('Sulu\Component\Rest\ListBuilder\PaginatedListRepresentation');
+            $argumentCount = \count($node->args);
+            unset($node->args[2], $node->args[3]);
+            for ($i = 4; $i < $argumentCount; ++$i) {
+                /** @var Arg $arg */
+                $arg = $node->args[$i];
+                $node->args[$i] = new Arg(new Int_($arg->value));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Rector/PaginatedRepresentationRector.php
+++ b/src/Rector/PaginatedRepresentationRector.php
@@ -24,11 +24,14 @@ class PaginatedRepresentationRector extends AbstractRector implements RectorInte
 
     public function refactor(Node $node)
     {
+        // @phpstan-ignore-next-line We need to refer to a deprecated class here.
+        $classToRefactor = ListRepresentation::class;
+
         // Removing the use statement of the class
         if ($node instanceof Use_) {
             $counter = \count($node->uses);
             for ($i = 0; $i < $counter; ++$i) {
-                if ($this->isName($node->uses[$i], ListRepresentation::class)) {
+                if ($this->isName($node->uses[$i], $classToRefactor)) {
                     unset($node->uses[$i]);
                 }
             }
@@ -39,7 +42,7 @@ class PaginatedRepresentationRector extends AbstractRector implements RectorInte
 
         // Refactoring all "new" calls to that class
         if ($node instanceof New_) {
-            if (!$this->isName($node->class, ListRepresentation::class)) {
+            if (!$this->isName($node->class, $classToRefactor)) {
                 return null;
             }
             $node->class = new FullyQualified('Sulu\Component\Rest\ListBuilder\PaginatedListRepresentation');

--- a/src/Rector/RequestParameterTraitRector.php
+++ b/src/Rector/RequestParameterTraitRector.php
@@ -40,6 +40,7 @@ class RequestParameterTraitRector extends AbstractRector implements RectorInterf
                         use RequestParameterTrait;
                         public function invoke(Request \$request) {
                             \$this->getRequestParameter(\$request, 'some_prop');
+                            \$this->getRequestParameter(\$request, 'other_prop', force: true);
                         }
                     }
                     CODE_SAMPLE,
@@ -47,6 +48,7 @@ class RequestParameterTraitRector extends AbstractRector implements RectorInterf
                     class Test {
                         public function invoke(Request \$request) {
                             \$request->get('some_prop');
+                            \$request->get('other_prop') ?? throw new InvalidArgumentException('Missing request parameter: "other _prop");
                         }
                     }
                     CODE_SAMPLE
@@ -126,7 +128,7 @@ class RequestParameterTraitRector extends AbstractRector implements RectorInterf
         $force = $arguments['force'];
         Assert::isInstanceOf($force, ConstFetch::class);
 
-        // IF FORCE IS false we can just convert it one to one to a symfony request call.
+        // If "force" is false we can just convert it one to one to a symfony request call.
         if ($this->isName($force->name, 'false')) {
             $methodCall->var = $request;
             $methodCall->name = new Identifier('get');
@@ -136,7 +138,7 @@ class RequestParameterTraitRector extends AbstractRector implements RectorInterf
             return $methodCall;
         }
 
-        // IF FORCE IS false we can just convert it one to one to a symfony request call.
+        // If "force" is true, convert it to a non optional call with exceptions
         if ($this->isName($force->name, 'true')) {
             // We don't want default values for this:
             if ($default instanceof ConstFetch && $this->isName($default->name, 'null')) {

--- a/src/Rector/RequestParameterTraitRector.php
+++ b/src/Rector/RequestParameterTraitRector.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Rector\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\NodeVisitor;
+use Rector\Contract\Rector\RectorInterface;
+use Rector\Rector\AbstractRector;
+use Sulu\Component\Rest\RequestParametersTrait;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+class RequestParameterTraitRector extends AbstractRector implements RectorInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Converts calls to RequestParameterTrait into Request calls',
+            [
+                new CodeSample(
+                    <<<CODE_SAMPLE
+                    class Test {
+                        use RequestParameterTrait;
+                        public function invoke(Request \$request) {
+                            \$this->getRequestParameter(\$request, 'some_prop');
+                        }
+                    }
+                    CODE_SAMPLE,
+                    <<<CODE_SAMPLE
+                    class Test {
+                        public function invoke(Request \$request) {
+                            \$request->get('some_prop');
+                        }
+                    }
+                    CODE_SAMPLE
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Use_::class, Class_::class, MethodCall::class];
+    }
+
+    public function refactor(Node $node)
+    {
+        if ($node instanceof Use_) {
+            $counter = \count($node->uses);
+            for ($i = 0; $i < $counter; ++$i) {
+                if ($this->isName($node->uses[$i], RequestParametersTrait::class)) {
+                    unset($node->uses[$i]);
+                }
+            }
+            if (0 === \count($node->uses)) {
+                return NodeVisitor::REMOVE_NODE;
+            }
+        }
+
+        if ($node instanceof Class_) {
+            $counter = \count($node->stmts);
+            for ($i = 0; $i < $counter; ++$i) {
+                $stmt = $node->stmts[$i];
+                if ($stmt instanceof TraitUse) {
+                    for ($j = 0; $j < \count($stmt->traits); ++$j) {
+                        if ($this->isName($stmt->traits[$j], RequestParametersTrait::class)) {
+                            unset($stmt->traits[$j]);
+                        }
+                    }
+                    if (0 === \count($stmt->traits)) {
+                        unset($node->stmts[$i]);
+                    }
+                }
+            }
+        }
+
+        if ($node instanceof MethodCall) {
+            return $this->refactorMethodCall($node);
+        }
+
+        return $node;
+    }
+
+    private function refactorMethodCall(MethodCall $methodCall): Expr
+    {
+        if ($this->nodeNameResolver->isName($methodCall->var, '$this')
+            || 'getRequestParameter' !== $this->getName($methodCall->name)) {
+            return $methodCall;
+        }
+
+        /** @var array<Arg> $args */
+        $args = $methodCall->args;
+        $arguments = $this->arguments($args, [
+            'request' => null,
+            'parameterName' => null,
+            'force' => $this->nodeFactory->createFalse(),
+            'default' => null,
+        ]);
+
+        $default = $arguments['default'];
+
+        $request = $arguments['request'];
+        Assert::isInstanceOf($request, Expr::class, 'Request parameter must be set');
+
+        $parameterName = $arguments['parameterName'];
+        Assert::isInstanceOf($parameterName, Expr::class, 'Parameter must be set');
+        Assert::isInstanceOf($parameterName, String_::class, 'Parameter name must be a string');
+
+        $force = $arguments['force'];
+        Assert::isInstanceOf($force, ConstFetch::class);
+
+        // IF FORCE IS false we can just convert it one to one to a symfony request call.
+        if ($this->isName($force->name, 'false')) {
+            $methodCall->var = $request;
+            $methodCall->name = new Identifier('get');
+
+            $methodCall->args = $this->createArguments($default, $parameterName);
+
+            return $methodCall;
+        }
+
+        // IF FORCE IS false we can just convert it one to one to a symfony request call.
+        if ($this->isName($force->name, 'true')) {
+            // We don't want default values for this:
+            if ($default instanceof ConstFetch && $this->isName($default->name, 'null')) {
+                throw new \InvalidArgumentException('You can not use "force" and default value');
+            }
+
+            return $this->createNonOptionalCalls($request, $parameterName);
+        }
+
+        throw new \InvalidArgumentException('The force parameter needs to be a constant.');
+    }
+
+    /**
+     * @param array<Arg> $arguments
+     * @param array<string, Expr|null> $definitions
+     *
+     * @return array<string, Expr|null>
+     */
+    private function arguments(array $arguments, array $definitions): array
+    {
+        $currentArgumentPosition = 0;
+        $names = \array_keys($definitions);
+        $result = [];
+        foreach ($arguments as $argument) {
+            if (null === $argument->name) {
+                // Get the argument name based on the position
+                $name = $names[$currentArgumentPosition++];
+                unset($definitions[$name]);
+            } else {
+                // Get the argument name from the named argument
+                $name = $this->getName($argument->name);
+            }
+            $result[$name] = $argument->value;
+        }
+
+        // Concatenate the remaining defaulted arguments
+        return [...$definitions, ...$result];
+    }
+
+    /**
+     * @return array<Arg>
+     */
+    private function createArguments(?Expr $default, Expr $parameterName): array
+    {
+        if (!$default instanceof Expr || $default instanceof ConstFetch && $this->isName($default->name, 'null')) {
+            return [new Arg($parameterName)];
+        }
+
+        return [new Arg($parameterName), new Arg($default)];
+    }
+
+    private function createNonOptionalCalls(Expr $expr, String_ $parameterName): Expr
+    {
+        $string = new String_(\sprintf('Missing request parameter: "%s"', $parameterName->value));
+
+        return new Coalesce(
+            left: new MethodCall(
+                $expr,
+                'get',
+                $this->createArguments(null, $parameterName),
+            ),
+            right: new Throw_(
+                expr: new New_(new FullyQualified(['InvalidArgumentException']), [new Arg($string)]),
+            ),
+        );
+    }
+}

--- a/src/Set/SuluLevelSetList.php
+++ b/src/Set/SuluLevelSetList.php
@@ -20,4 +20,9 @@ final class SuluLevelSetList
      * @var string
      */
     final public const UP_TO_SULU_26 = __DIR__ . '/../../config/sets/sulu/level/up-to-sulu-26.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_SULU_30 = __DIR__ . '/../../config/sets/sulu/level/up-to-sulu-30.php';
 }

--- a/src/Set/SuluSetList.php
+++ b/src/Set/SuluSetList.php
@@ -20,4 +20,9 @@ final class SuluSetList
      * @var string
      */
     final public const SULU_26 = __DIR__ . '/../../config/sets/sulu/sulu-26.php';
+
+    /**
+     * @var string
+     */
+    final public const SULU_30 = __DIR__ . '/../../config/sets/sulu/sulu-30.php';
 }

--- a/tests/Rector/ListBuilderInterfaceRector/Fixture/test_refactor.php.inc
+++ b/tests/Rector/ListBuilderInterfaceRector/Fixture/test_refactor.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
+
+class Test implements ListBuilderInterface
+{
+    public function invoke() {
+        $this->whereNot($fieldDescriptor, 'value');
+    }
+}
+-----
+<?php
+
+use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
+
+class Test implements ListBuilderInterface
+{
+    public function invoke() {
+        $this->where($fieldDescriptor, 'value', ListBuilderInterface::WHERE_COMPARATOR_UNEQUAL);
+    }
+}

--- a/tests/Rector/ListBuilderInterfaceRector/ListBuilderInterfaceRectorTest.php
+++ b/tests/Rector/ListBuilderInterfaceRector/ListBuilderInterfaceRectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Rector\Tests\Rector\ListBuilderInterfaceRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class ListBuilderInterfaceRectorTest extends AbstractRectorTestCase
+{
+    /** @dataProvider provideData  */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/ListBuilderInterfaceRector/config/config.php
+++ b/tests/Rector/ListBuilderInterfaceRector/config/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Sulu\Rector\Rector\ListBuilderInterfaceRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        ListBuilderInterfaceRector::class,
+    ]);

--- a/tests/Rector/PaginatedRepresentationRector/Fixture/test_refactor.php.inc
+++ b/tests/Rector/PaginatedRepresentationRector/Fixture/test_refactor.php.inc
@@ -19,12 +19,10 @@ class Test implements ListBuilderInterface
 -----
 <?php
 
-use Sulu\Component\Rest\ListBuilder\ListRepresentation;
-
 class Test implements ListBuilderInterface
 {
     public function invoke() {
-        return new PaginatedRepresentation(
+        return new \Sulu\Component\Rest\ListBuilder\PaginatedListRepresentation(
             $activities,
             ActivityInterface::RESOURCE_KEY,
             (int) $listBuilder->getCurrentPage(),

--- a/tests/Rector/PaginatedRepresentationRector/Fixture/test_refactor.php.inc
+++ b/tests/Rector/PaginatedRepresentationRector/Fixture/test_refactor.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+use Sulu\Component\Rest\ListBuilder\ListRepresentation;
+
+class Test implements ListBuilderInterface
+{
+    public function invoke() {
+        return new ListRepresentation(
+            $activities,
+            ActivityInterface::RESOURCE_KEY,
+            'sulu_activity.get_activities',
+            $request->query->all(),
+            $listBuilder->getCurrentPage(),
+            $listBuilder->getLimit(),
+            $listBuilder->count()
+        );
+    }
+}
+-----
+<?php
+
+use Sulu\Component\Rest\ListBuilder\ListRepresentation;
+
+class Test implements ListBuilderInterface
+{
+    public function invoke() {
+        return new PaginatedRepresentation(
+            $activities,
+            ActivityInterface::RESOURCE_KEY,
+            (int) $listBuilder->getCurrentPage(),
+            (int) $listBuilder->getLimit(),
+            (int) $listBuilder->count()
+        );
+    }
+}

--- a/tests/Rector/PaginatedRepresentationRector/PaginatedRepresentationRectorTest.php
+++ b/tests/Rector/PaginatedRepresentationRector/PaginatedRepresentationRectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Rector\Tests\Rector\PaginatedRepresentationRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class PaginatedRepresentationRectorTest extends AbstractRectorTestCase
+{
+    /** @dataProvider provideData  */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/PaginatedRepresentationRector/config/config.php
+++ b/tests/Rector/PaginatedRepresentationRector/config/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Sulu\Rector\Rector\PaginatedRepresentationRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        PaginatedRepresentationRector::class,
+    ]);

--- a/tests/Rector/RequestParameterTraitRector/Fixture/test_refactor_forced.php.inc
+++ b/tests/Rector/RequestParameterTraitRector/Fixture/test_refactor_forced.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+use Sulu\Component\Rest\RequestParametersTrait;
+use Symfony\Component\HttpFoundation\Request;
+
+class SomeController
+{
+    use RequestParametersTrait;
+
+    public function __invoke(Request $request)
+    {
+        $format = $this->getRequestParameter($request, 'format', true);
+    }
+}
+-----
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class SomeController
+{
+    public function __invoke(Request $request)
+    {
+        $format = $request->get('format') ?? (throw new \InvalidArgumentException('Missing request parameter: "format"'));
+    }
+}

--- a/tests/Rector/RequestParameterTraitRector/Fixture/test_refactor_named.php.inc
+++ b/tests/Rector/RequestParameterTraitRector/Fixture/test_refactor_named.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+use Sulu\Component\Rest\RequestParametersTrait;
+use Symfony\Component\HttpFoundation\Request;
+
+class SomeController
+{
+    use RequestParametersTrait;
+
+    public function __invoke(Request $request, $id)
+    {
+        $format = $this->getRequestParameter($request, 'format', default: 'xml');
+    }
+}
+-----
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class SomeController
+{
+    public function __invoke(Request $request, $id)
+    {
+        $format = $request->get('format', 'xml');
+    }
+}

--- a/tests/Rector/RequestParameterTraitRector/Fixture/test_refactor_none.php.inc
+++ b/tests/Rector/RequestParameterTraitRector/Fixture/test_refactor_none.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+
+class SomeController
+{
+    public function __invoke(Request $request)
+    {
+        return new Response();
+    }
+}

--- a/tests/Rector/RequestParameterTraitRector/Fixture/test_refactor_optional.php.inc
+++ b/tests/Rector/RequestParameterTraitRector/Fixture/test_refactor_optional.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+use Sulu\Component\Rest\RequestParametersTrait;
+use Symfony\Component\HttpFoundation\Request;
+
+class SomeController
+{
+    use RequestParametersTrait;
+
+    public function __invoke(Request $request, $id)
+    {
+        $format = $this->getRequestParameter($request, 'format');
+    }
+}
+-----
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class SomeController
+{
+    public function __invoke(Request $request, $id)
+    {
+        $format = $request->get('format');
+    }
+}

--- a/tests/Rector/RequestParameterTraitRector/RequestParameterTraitRectorTest.php
+++ b/tests/Rector/RequestParameterTraitRector/RequestParameterTraitRectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Rector\Tests\Rector\RequestParameterTraitRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class RequestParameterTraitRectorTest extends AbstractRectorTestCase
+{
+    /** @dataProvider provideData  */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/RequestParameterTraitRector/config/config.php
+++ b/tests/Rector/RequestParameterTraitRector/config/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Sulu\Rector\Rector\RequestParameterTraitRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        RequestParameterTraitRector::class,
+    ]);


### PR DESCRIPTION
## Method Renames
Adding method renames to the 2.6 version, as this can already be done in the old version. Otherwise they would be part of the UP_TO_2_6 migration.

## RequestParameterTrait

I've added a rector to refactor this. Mostly cause I wanted to try to use rector but also to help the upgrade that people want to make. The generated code is not the most optimal (as we can't determine the parameter is from) but it works the same as before.

Seeing that the `MissingParameterException` is also deprecated it has now been replaced with an `InvalidArgumentException` which will result in a 500 error code.

Related: https://github.com/sulu/sulu/pull/7815

## Replacing deprecated ListRepresentation
Now it automatically refactors it to the PaginatedVersion with additional `int` casts in case of defective types.

## Adding Sulu Level 3.0
(stolen from https://github.com/sulu/sulu-rector/pull/18)

## TODO
- [ ] Adding the class renames after moving bundles to the core.